### PR TITLE
End page without bucket

### DIFF
--- a/components/EndPageContent.tsx
+++ b/components/EndPageContent.tsx
@@ -8,7 +8,7 @@ import PollResults from "./PollResults";
 
 interface Props {
   poll: Poll;
-  bucket: Bucket;
+  bucket?: Bucket;
 }
 
 const headlineStyle = css`
@@ -29,8 +29,7 @@ const EndPageContent = ({ poll, bucket }: Props) => {
         <h1 css={headlineStyle}>{poll.title}</h1>
       </Container>
       <Container sideBorders topBorder>
-        <p css={paragraphStyle}>{bucket.text}</p>
-
+        {bucket && <p css={paragraphStyle}>{bucket.text}</p>}
         <Link href="/" passHref={true}>
           <Button>back to homepage</Button>
         </Link>

--- a/components/EndPageContent.tsx
+++ b/components/EndPageContent.tsx
@@ -29,6 +29,7 @@ const EndPageContent = ({ poll, bucket }: Props) => {
         <h1 css={headlineStyle}>{poll.title}</h1>
       </Container>
       <Container sideBorders topBorder>
+        <p css={paragraphStyle}>{poll.endPageText}</p>
         {bucket && <p css={paragraphStyle}>{bucket.text}</p>}
         <Link href="/" passHref={true}>
           <Button>back to homepage</Button>

--- a/pages/end-page/[id]/index.tsx
+++ b/pages/end-page/[id]/index.tsx
@@ -1,0 +1,50 @@
+import type { NextPage } from "next";
+import Head from "next/head";
+import EndPageContent from "../../../components/EndPageContent";
+import { polls } from "../../../poll-data";
+import { Poll } from "../../../poll-data/types";
+
+interface EndPageProps {
+  pollId: string;   
+  poll?: Poll;
+}
+
+const EndPage: NextPage = (props: EndPageProps) => {
+  const { pollId, poll } = props;
+
+  return (
+    <div>
+      <Head>
+        <title>Poll - {pollId}</title>
+      </Head>
+
+      <main>
+        {!!(poll) && <EndPageContent poll={poll} />}
+      </main>
+    </div>
+  );
+};
+
+export const getStaticProps = async (context: {
+  params: { id: string };
+}): Promise<{ props: EndPageProps }> => {
+  const poll = polls.find((poll) => poll.id === context.params.id);
+
+  return {
+    props: {
+      pollId: context.params.id,
+      poll,
+    },
+  };
+};
+
+export async function getStaticPaths() {
+  const paths = polls.map(poll => `/end-page/${poll.id}`)
+  
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export default EndPage;

--- a/poll-data/index.ts
+++ b/poll-data/index.ts
@@ -4,6 +4,7 @@ export const polls: Poll[] = [
   {
     id: "test-poll",
     title: "Our test poll",
+    endPageText: "This is a test poll.",
     questions: [
       {
         text: "Who will win the world cup?",
@@ -20,6 +21,7 @@ export const polls: Poll[] = [
   {
     id: "politics-poll",
     title: "The Election 2024",
+    endPageText: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     questions: [
       {
         text: "Who will win the election?",

--- a/poll-data/types.ts
+++ b/poll-data/types.ts
@@ -15,6 +15,7 @@ export type Bucket = {
 export type Poll = {
   id: string;
   title: string;
+  endPageText: string;
   questions: QuestionAndAnswers[];
   buckets: Bucket[];
 };


### PR DESCRIPTION
Creates an end page without a "bucket"  - so we can link a version of the results page for users who didn't voted.
Adds general content to the sample poll data (`Poll.endPage.Text`) to be shown whether we have a user bucket or not.

eg : http://localhost:3000/end-page/politics-poll